### PR TITLE
feat: Display instance name in header and hero

### DIFF
--- a/src/context/InstanceContext.jsx
+++ b/src/context/InstanceContext.jsx
@@ -21,7 +21,7 @@ export const InstanceProvider = ({ children }) => {
             if (!id) return;
             setLoading(true);
             try {
-                const response = await axios.get(`http://localhost:3000/api/instances/${id}`);
+                const response = await axios.get(`/api/instances/${id}`);
                 setInstance(response.data);
             } catch (err) {
                 setError(err);


### PR DESCRIPTION
This commit implements the functionality to display the instance name in the header and hero section of the application.

- Adds a public API endpoint to fetch instance data by ID.
- Enhances `InstanceProvider` to fetch and provide instance data to the frontend.
- Updates `Hero.jsx` and `Header.jsx` to consume the instance name from the context.
- Adds `axios` as a dependency for making API requests.
- Fixes a bug in the stats endpoint that caused unnecessary database writes.
- Uses a relative path for the API endpoint to support external access via tools like ngrok.